### PR TITLE
added a way to override default date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Pikaday has many useful options:
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
+* `parseOverride` function to manually parse date strings.  Must return a native Date.  Parameters: dateString, formatString
 
 ## jQuery Plugin
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -447,7 +447,10 @@
             if (e.firedBy === self) {
                 return;
             }
-            if (hasMoment) {
+            if (opts.parseOverride) {
+                date = opts.parseOverride(opts.field.value, opts.format);
+            }
+            else if (hasMoment) {
                 date = moment(opts.field.value, opts.format);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }


### PR DESCRIPTION
In a project I'm working on, I needed a way to do more with the date parsing than the default Pikaday allows.  The easiest and most flexible way was to just add an option to override the default date parsing.
