### PR TITLE
Add 'events' option, to differentiate regular days from "reserved" ones with differents type of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Pikaday has many useful options:
 * `showMonthAfterYear` render the month after year in the title (default `false`)
 * `numberOfMonths` number of visible calendars
 * `mainCalendar` when `numberOfMonths` is used, this will help you to choose where the main calendar will be (default `left`, can be set to `right`). Only used for the first display or when a selected date is not already visible
+* `events` array of dates that you would like to differentiate from regular days choose one of the two form : 'Sat Jun 28 2014' or { date: new Date('Sat Jun 28 2014'), backgroundColor: '#000000', color: '#FFFFFF' }(e.g. `['Sat Jun 28 2014', 'Sun Jun 29 2014', 'Tue Jul 01 2014',]`)
 * `onSelect` callback function for when a date is selected
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden
@@ -214,6 +215,18 @@ Update the minimum/earliest date that can be selected.
 `picker.setMaxDate()`
 
 Update the maximum/latest date that can be selected.
+
+`picker.addEvents()`
+
+Add an event to show (choose between the date.ToStringDate() form and the {date: date, backgroundColor: background-color, color: color} form).
+
+`picker.removeEvents()`
+
+Remove an event (need a date.ToStringDate() form).
+
+`picker.getEvents()`
+
+Return the list of all the saved events as they were saved.
 
 ### Show and hide datepicker
 

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+﻿@charset "UTF-8";
 
 /*!
  * Pikaday
@@ -171,7 +171,8 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     font-weight: bold;
 }
 
-.is-selected .pika-button {
+.is-selected .pika-button,
+.has-event .pika-button {
     color: #fff;
     font-weight: bold;
     background: #33aaff;
@@ -184,6 +185,15 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     cursor: default;
     color: #999;
     opacity: .3;
+}
+
+.has-event .pika-button {
+    background: #005da9;
+    box-shadow: inset 0 1px 3px #CCCCCC;
+}
+
+.is-today.has-event .pika-button {
+    color: #00FF00 !important;
 }
 
 .pika-button:hover {


### PR DESCRIPTION
I needed the feature implemented by #152 but with possibility to use my own set of colors so I did that.
Here is my code when I use it :

this.Picker = this.$('#outageDates').pikaday({
            events: [{ date: new Date('Sun Aug 10 2014'), backgroundColor: '#0099FF', color: '#000000' }] // or 'Sun Aug 10 2014' form
}).data('pikaday');

```
    this.Picker.addEvents({ date: new Date('Fri Aug 01 2014'), backgroundColor: '#000000', color: '#FFFFFF' });
    this.Picker.addEvents({ backgroundColor: '#0099FF', color: '#FFFFFF', date: new Date('Sat Aug 02 2014') });
    this.Picker.addEvents({ backgroundColor: '#9966FF', color: '#FFFFFF', date: new Date('Sun Aug 03 2014') });
    this.Picker.addEvents({ backgroundColor: '#FF0033', color: '#FFFFFF', date: new Date('Mon Aug 04 2014') });
    this.Picker.addEvents({ backgroundColor: '#993300', color: '#FFFFFF', date: new Date('Tue Aug 05 2014') });
```

/\*      You can choose this way of declaring events too but you have to keep the same form all he time : object or Date string
        this.Picker.addEvents('Fri Aug 01 2014');
        this.Picker.addEvents('Sat Aug 02 2014');
        this.Picker.addEvents('Sun Aug 03 2014');
        this.Picker.addEvents('Mon Aug 04 2014');
        this.Picker.addEvents('Tue Aug 05 2014');
*/
        this.Picker.removeEvents(new Date('Sun Aug 03 2014'));

```
    this.Picker.getEvents();
```
