### PR TITLE
Fixed min/max date bug

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -773,20 +773,47 @@
             }
         },
 
+        
         /**
          * change the minDate
          */
-        setMinDate: function(value)
+        setMinDate: function (value) 
         {
-            this._o.minDate = value;
+            var opts = this._o;
+
+            setToStartOfDay(value);
+            
+            opts.minDate = value;
+
+            if (opts.minDate) {
+                opts.minYear = opts.minDate.getFullYear();
+                opts.minMonth = opts.minDate.getMonth();
+            }
+            else {
+                opts.minYear = undefined;
+                opts.minMonth = undefined;
+            }
         },
 
         /**
          * change the maxDate
          */
-        setMaxDate: function(value)
+        setMaxDate: function (value)
         {
-            this._o.maxDate = value;
+            var opts = this._o;
+
+            setToStartOfDay(value);
+
+            opts.maxDate = value;
+            
+            if (opts.maxDate) {
+                opts.maxYear = opts.maxDate.getFullYear();
+                opts.maxMonth = opts.maxDate.getMonth();
+            }
+            else {
+                opts.maxYear = undefined;
+                opts.maxMonth = undefined;
+            }
         },
 
         /**

--- a/pikaday.js
+++ b/pikaday.js
@@ -184,6 +184,9 @@
         // the default output format for `.toString()` and `field` value
         format: 'YYYY-MM-DD',
 
+        // if true, when using moment JS the entered date must exactly match the format
+        strictParsing: false,
+		
         // the initial date to view when first opened
         defaultDate: null,
 
@@ -448,7 +451,7 @@
                 return;
             }
             if (hasMoment) {
-                date = moment(opts.field.value, opts.format);
+                date = moment(opts.field.value, opts.format, opts.strictParsing);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
             else {


### PR DESCRIPTION
If a minimum or maximum date was specified in the initial creation options, it also sets the (min|max)Year and (min|max)Month properties. These properties weren't updated if the minimum or maximum dates were changed after creation.
