### PR TITLE
Add onToString callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ See the [moment.js example][] for a full version.
 </script>
 ```
 
+For simple formatting the `onToString` callback can be used to intercept the value written
+to the bound form field. The single parameter passed is the result of a `toDateString()` call on the 
+picked date and the value returned by the callback will be inserted into the bound field.
+
 ### Configuration
 
 As the examples demonstrate above
@@ -97,7 +101,8 @@ Pikaday has many useful options:
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
-
+* `onToString` callback function for when the picker outputs to the bound form field
+* 
 ## jQuery Plugin
 
 The normal version of Pikaday does not require jQuery, however there is a jQuery plugin if that floats your boat (see `plugins/pikaday.jquery.js` in the repository). This version requires jQuery, naturally, and can be used like other plugins:  

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Pikaday has many useful options:
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
 * `onToString` callback function for when the picker outputs to the bound form field
-* 
+
 ## jQuery Plugin
 
 The normal version of Pikaday does not require jQuery, however there is a jQuery plugin if that floats your boat (see `plugins/pikaday.jquery.js` in the repository). This version requires jQuery, naturally, and can be used like other plugins:  

--- a/pikaday.js
+++ b/pikaday.js
@@ -241,7 +241,8 @@
         onSelect: null,
         onOpen: null,
         onClose: null,
-        onDraw: null
+        onDraw: null,
+        onToString: null
     },
 
 
@@ -622,7 +623,7 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : (this._o.onToString) ? this._o.onToString(this._d.toDateString()) : this._d.toDateString();
         },
 
         /**


### PR DESCRIPTION
Callback added to intercept the text output written to the bound form field. This enables the raw output of the `.toDateString()` function applied to the js `Date` object to be converted and re-formatted without needing heavy-weight libraries like moment.js. (this mod also allows the "western timezone" problem to be avoided)
