### PR TITLE
Use optional outputFormat for single formatting, allow moment JS to hand...

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -184,8 +184,11 @@
         // automatically fit in the viewport even if it means repositioning from the position option
         reposition: true,
 
-        // the default output format for `.toString()` and `field` value
+        // the default parsing format for moment
         format: 'YYYY-MM-DD',
+       
+        // the default output format for `.toString()` and `field` value
+        outputFormat: 'YYYY-MM-DD',
 
         // the initial date to view when first opened
         defaultDate: null,
@@ -567,7 +570,7 @@
         /**
          * configure functionality
          */
-        config: function(options)
+        config: function (options)
         {
             if (!this._o) {
                 this._o = extend({}, defaults, true);
@@ -582,6 +585,11 @@
             opts.bound = !!(opts.bound !== undefined ? opts.field && opts.bound : opts.field);
 
             opts.trigger = (opts.trigger && opts.trigger.nodeName) ? opts.trigger : opts.field;
+
+            // If output format was not explicitly set and momentJS format specification is not an array, use the same format
+            if (!opts.outputFormat && typeof options.format == "string") {
+                opts.outputFormat = opts.format;
+            }
 
             var nom = parseInt(opts.numberOfMonths, 10) || 1;
             opts.numberOfMonths = nom > 4 ? 4 : nom;
@@ -625,7 +633,7 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.outputFormat) : this._d.toDateString();
         },
 
         /**

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -12,11 +12,21 @@ describe('Pikaday public method', function ()
             var pikaday = new Pikaday();
             expect(pikaday.toString()).to.be.empty;
         });
+        
+	it('should return date string, formatted by moment, when date is set', function() {
+            var date = new Date(2014, 3, 25),
+            pikaday = new Pikaday({
+                format: 'DD-MM-YY'
+            });
+
+            pikaday.setDate(date);
+            expect(pikaday.toString()).to.eql('25-04-14');
+        });
 
         it('should return date string, formatted by moment, when date is set', function() {
             var date = new Date(2014, 3, 25),
             pikaday = new Pikaday({
-                format: 'DD-MM-YY'
+                outputFormat: 'DD-MM-YY'
             });
 
             pikaday.setDate(date);


### PR DESCRIPTION
...le multiple input formats

This is intended to address the following issue:
https://github.com/dbushell/Pikaday/issues/142

There can be only one output format, regardless of how many input formats you want to handle (using MomentJS), so this patch allows explicitly specifying which output format you want to use. There's some sanity-checking in terms of which values to use by default if the "format" option is specified (and singular), but the "outputFormat" option is not specified.
