### PR TITLE
Fix 1.3.3 release date in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.0 - TBA
 
-## 1.3.3 - 2015-02-17
+## 1.3.3 - 2015-06-26
 
 - Add theme class support, see #260
 - Fix on iOS, see #101, #121


### PR DESCRIPTION
I believe 2015-02-17 was a copy and paste typo, might be worth fixing to avoid any confusion
