### PR TITLE
Add support for dateFormatFn and dateParseFn options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.4.0 - TBA
 
+- Add support for custom date parsing / formatting - see [#378](https://github.com/dbushell/Pikaday/pull/378]). (Also 
+[#128](https://github.com/dbushell/Pikaday/pull/128), 
+[#160](https://github.com/dbushell/Pikaday/pull/160), 
+[#278](https://github.com/dbushell/Pikaday/pull/278]).)
+
 ## 1.3.3 - 2015-02-17
 
 - Add theme class support, see #260

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Pikaday has many useful options:
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined) 
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
+* `dateFormatFn` callback function used to convert the selected date to a string for populating the form field.
+* `dateParseFn` callback function used to parse the form field value into a date.
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)

--- a/examples/custom-date-format.html
+++ b/examples/custom-date-format.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - moment.js example</title>
+    <meta name="author" content="Ramiro Rikkert">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+    <h1>Pikaday - Custom date format example</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p>
+        The <code>dateFormatFn</code> and <code>dateParseFn</code> callbacks can be used to apply custom formatting and parsing of the selected date.<br>
+        This can be used to control the value written into the field which Pikaday is bound to.<br>
+        This is also useful if you want to integrate a 3rd party parser or formatter eg <a href="http://sugarjs.com/dates">Sugar JS - Dates</a>, <a href="https://github.com/taylorhakes/fecha">Fecha</a>, etc.<br>
+    </p>
+    <label for="datepicker">Date:</label>
+    <br>
+    <input type="text" id="datepicker">
+    <div id="selected"></div>
+    <br>
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/rikkert">Ramiro Rikkert</a></p>
+
+
+    <script src="../pikaday.js"></script>
+    <script>
+
+    var picker = new Pikaday({
+        field: document.getElementById('datepicker'),
+        dateFormatFn: function(date, format) {
+            return date.getDate() + "/" + (date.getMonth()+1) + "/" + date.getFullYear();
+        },
+        dateParseFn: function(fieldValue, format) {
+            var parts = fieldValue.split("/");
+            return new Date(parts[2], parts[1]-1, parts[0]);
+        }
+    });
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR is another attempt at adding support for formatting and parsing callbacks.

There are several previous PRs which do this: https://github.com/dbushell/Pikaday/pull/128, https://github.com/dbushell/Pikaday/pull/160, https://github.com/dbushell/Pikaday/pull/278

My approach differs somewhat in that the functions are only configured at initialization time, which means that the moment.js check is only done once rather than every time a date is parsed / selected. Obviously the performance improvement is negligible, but I think this is a bit cleaner.

This PR also addresses https://github.com/dbushell/Pikaday/pull/278#issuecomment-106563472; ie if `dateFormatFn` or `dateParseFn` are specified, the moment js behaviour isn't invoked. I believe this could be used to implement [strict typing](https://github.com/dbushell/Pikaday/pull/290) without the need for another moment specific option:

``` js
var picker = new Pikaday({
    field: document.getElementById('datepicker'),
    dateParseFn: function(fieldValue, format) {
        var date = moment(fieldValue, format, true); // passing true turns on strict typing
        return (date && date.isValid()) ? date.toDate() : null;
    }
});
```

I have updated the CHANGELOG, README and added an example, but I couldn't work out how to run the tests. If someone can advise, and there is a desire to merge this, I will add tests.
