### PR TITLE
Allow passing array of formats for format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Pikaday has many useful options:
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
-* `container` DOM node to render calendar into, see [container example][] (default: undefined) 
-* `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
+* `container` DOM node to render calendar into, see [container example][] (default: undefined)
+* `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting). Accepts a single `String` or an `Array`. If provided an `Array` the entire array will be passed to [Moment.js][moment] when parsing user input and `.toString()` will use the first format in the `Array`.
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)

--- a/pikaday.js
+++ b/pikaday.js
@@ -119,6 +119,11 @@
         return year % 4 === 0 && year % 100 !== 0 || year % 400 === 0;
     },
 
+    getFirstFormat = function(format)
+    {
+      return isArray(format) ? format[0] : format;
+    },
+
     getDaysInMonth = function(year, month)
     {
         return [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
@@ -662,7 +667,7 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || getFirstFormat(this._o.format)) : this._d.toDateString();
         },
 
         /**


### PR DESCRIPTION
If moment is installed it can accept an array of formats that allows for
parsing different user inputs into a valid date. This commit modifies
the `toString()` method so that if `format` is an array, it will use the
first item. This allows us to parse different formats from user input,
but always display a consistent format.
