### PR TITLE
Update pikaday.css

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -26,7 +26,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     display: table;
 }
 .pika-single:after { clear: both }
-.pika-single { *zoom: 1 }
 
 .pika-single.is-hidden {
     display: none;
@@ -50,7 +49,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 
 .pika-label {
     display: inline-block;
-    *display: inline;
     position: relative;
     z-index: 9999;
     overflow: hidden;
@@ -91,8 +89,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     background-repeat: no-repeat;
     background-size: 75% 75%;
     opacity: .5;
-    *position: absolute;
-    *top: 0;
 }
 
 .pika-prev:hover,
@@ -104,14 +100,12 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 .is-rtl .pika-next {
     float: left;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAeCAYAAAAsEj5rAAAAUklEQVR42u3VMQoAIBADQf8Pgj+OD9hG2CtONJB2ymQkKe0HbwAP0xucDiQWARITIDEBEnMgMQ8S8+AqBIl6kKgHiXqQqAeJepBo/z38J/U0uAHlaBkBl9I4GwAAAABJRU5ErkJggg==');
-    *left: 0;
 }
 
 .pika-next,
 .is-rtl .pika-prev {
     float: right;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAeCAYAAAAsEj5rAAAAU0lEQVR42u3VOwoAMAgE0dwfAnNjU26bYkBCFGwfiL9VVWoO+BJ4Gf3gtsEKKoFBNTCoCAYVwaAiGNQGMUHMkjGbgjk2mIONuXo0nC8XnCf1JXgArVIZAQh5TKYAAAAASUVORK5CYII=');
-    *right: 0;
 }
 
 .pika-prev.is-disabled,
@@ -122,7 +116,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 
 .pika-select {
     display: inline-block;
-    *display: inline;
 }
 
 .pika-table {


### PR DESCRIPTION
Removed IE7 selector hacks.  Not needed anymore, and they trigger invalid CSS warnings in WebKit.
