### PR TITLE
change isLeapYear() to remove stackoverflow code

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -115,8 +115,8 @@
 
     isLeapYear = function(year)
     {
-        // solution by Matti Virkkunen: http://stackoverflow.com/a/4881951
-        return year % 4 === 0 && year % 100 !== 0 || year % 400 === 0;
+        // solution lifted from date.js (MIT license): https://github.com/datejs/Datejs
+        return ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0);
     },
 
     getDaysInMonth = function(year, month)


### PR DESCRIPTION
Replace isLeapYear() method with code from a permissive license, due to StackOverflow code being under a more restrictive license (and general ambiguity surrounding using S.O. code).
