### PR TITLE
Solve issue #451: disabled field triggers error on focus in (at leas…

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -898,7 +898,9 @@
             if (opts.bound) {
                 if(opts.field.type !== 'hidden') {
                     sto(function() {
-                        opts.trigger.focus();
+                        if (!opts.field.disabled) {
+                            opts.trigger.focus();
+                        }
                     }, 1);
                 }
             }


### PR DESCRIPTION
disabled field triggers error on focus in (at least) IE7

Add condition to focus action in draw. Can't/shouldn't focus a disabled field.

Note: since for my use case the disabled setting is changed at run time by the client before the timeout triggers, the disabled attribute must be set within the anonymous function itself.
