### PR TITLE
Fix the lack of space causing invalid XHTML

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -360,7 +360,7 @@
         for (arr = [], i = 0; i < 12; i++) {
             arr.push('<option value="' + (year === refYear ? i - c : 12 + i - c) + '"' +
                 (i === month ? ' selected="selected"': '') +
-                ((isMinYear && i < opts.minMonth) || (isMaxYear && i > opts.maxMonth) ? 'disabled="disabled"' : '') + '>' +
+                ((isMinYear && i < opts.minMonth) || (isMaxYear && i > opts.maxMonth) ? ' disabled="disabled"' : '') + '>' +
                 opts.i18n.months[i] + '</option>');
         }
 


### PR DESCRIPTION
Disabled tag on the options did not have a space before it meaning it was concatenated with whatever was previously written. This is fine for non-XHTML but Chrome outputs an error about invalid XML : 
"pikaday.js:970 Uncaught SyntaxError: Failed to set the 'innerHTML' property on 'Element': The provided markup is invalid XML, and therefore cannot be inserted into an XML document."
