### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+node_modules
+.c9revisions
+.c9
+examples
+tests
+.editorconfig
+.gitattributes
+.jshintrc
+.npmignore
+bower.json
+CHANGELOG.md
+index.html


### PR DESCRIPTION
My pikaday 1.4.0 installation contains quite a few files that are not needed for running the code. This `.npmignore` script excludes these files from the package. I was unsure about index.html and CHANGELOG.md, so if you feel they should be included in the packages I'll change my pull request.
