### PR TITLE
Running jQuery demo on local machine

### DIFF
--- a/examples/jquery.html
+++ b/examples/jquery.html
@@ -26,7 +26,7 @@
     <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/rikkert">Ramiro Rikkert</a></p>
 
 
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <!-- First load pikaday.js and then the jQuery plugin -->
     <script src="../pikaday.js"></script>
     <script src="../plugins/pikaday.jquery.js"></script>


### PR DESCRIPTION
`<script src="//path">` works great when you run a demo on a local webserver, but opening the demo file on your local will try to find jQuery on `file:///`. Adding `https:` or `http:` makes sure the demo will also run straight out of the zip.
