### PR TITLE
Add tests and examples to bower.json ignores

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,9 @@
   "ignore": [
     "**/.*",
     "node_modules",
-    "components"
+    "components",
+    "examples",
+    "tests"
   ],
   "license" : [
     "BSD",


### PR DESCRIPTION
As they are not needed in production, so they will not appear in installed package
