### PR TITLE
e.preventDefault() removed on left arrow key

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -524,7 +524,6 @@
                         }
                         break;
                     case 37:
-                        e.preventDefault();
                         self.adjustDate('subtract', 1);
                         break;
                     case 38:


### PR DESCRIPTION
e.preventDefault() removed on left arrow key. This causes issue when using pikaday in combination with other text input fields.