### PR TITLE
Add an option to sort year dropdown ascending or descending

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Pikaday has many useful options:
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)
 * `minDate` the minimum/earliest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
 * `maxDate` the maximum/latest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
+* `yearOrderMinMax` the sorted order of the years displayed in the dropdown, defaults to true
 * `disableWeekends` disallow selection of Saturdays or Sundays
 * `disableDayFn` callback function that gets passed a Date object for each day in view. Should return true to disable selection of that day.
 * `yearRange` number of years either side (e.g. `10`) or array of upper/lower range (e.g. `[1900,2015]`)

--- a/pikaday.js
+++ b/pikaday.js
@@ -219,6 +219,8 @@
         minDate: null,
         // the maximum/latest date that can be selected
         maxDate: null,
+        // the year selector sorted with minimum/earliest year at the top
+        yearOrderMinMax: true,
 
         // number of years either side, or array of upper/lower range
         yearRange: 10,
@@ -407,11 +409,20 @@
             j = 1 + year + opts.yearRange;
         }
 
-        for (arr = []; i < j && i <= opts.maxYear; i++) {
-            if (i >= opts.minYear) {
-                arr.push('<option value="' + i + '"' + (i === year ? ' selected="selected"': '') + '>' + (i) + '</option>');
+        if (opts.yearOrderMinMax) {
+            for (arr = []; i < j && i <= opts.maxYear; i++) {
+                if (i >= opts.minYear) {
+                    arr.push('<option value="' + i + '"' + (i === year ? ' selected="selected"': '') + '>' + (i) + '</option>');
+                }
+            }
+        } else {
+            for (arr = []; j > i && j >= opts.minYear; j--) {
+                if (j <= opts.maxYear) {
+                    arr.push('<option value="' + j + '"' + (j === year ? ' selected="selected"': '') + '>' + (j) + '</option>');
+                }
             }
         }
+            
         yearHtml = '<div class="pika-label">' + year + opts.yearSuffix + '<select class="pika-select pika-select-year" tabindex="-1">' + arr.join('') + '</select></div>';
 
         if (opts.showMonthAfterYear) {


### PR DESCRIPTION
Added support for optionally sorting the rendered title's Years from max to min via the new yearOrderMinMax boolean value (defaulted to **true** to maintain original behavior), updated the README.md to include option definition