### PR TITLE
Fix #237

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -153,6 +153,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     line-height: 15px;
     text-align: right;
     background: #f5f5f5;
+    height: initial;
 }
 
 .pika-week {

--- a/scss/pikaday.scss
+++ b/scss/pikaday.scss
@@ -190,6 +190,7 @@ $pd-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
     line-height: 15px;
     text-align: right;
     background: $pd-day-bg;
+    height: initial;
 
     .is-today & {
         color: $pd-day-today-color;


### PR DESCRIPTION
This will enforce the `.pika-button` to be rendered with correct height.

Pardon the [5fad73a](https://github.com/josephting/Pikaday/commit/5fad73a3a5b23c61043d84fe2bc13fc884957174) commit with incorrect user email.
It has been overwritten by [5234bd1](https://github.com/josephting/Pikaday/commit/5234bd10538c72b9770618cd10c8877ddeafc511).