### PR TITLE
New option "firstWeekOfYearMinDays" for regional week numbering rules support

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -212,6 +212,9 @@
         // first day of week (0: Sunday, 1: Monday etc)
         firstDay: 0,
 
+        // minimum number of days in the week that gets week number one
+        firstWeekOfYearMinDays: 4,
+
         // the default flag for moment's strict date parsing
         formatStrict: false,
 
@@ -349,7 +352,7 @@
                '</td>';
     },
 
-    isoWeek = function(date) {
+    isoWeek = function(date, firstWeekOfYearMinDays) {
         // Ensure we're at the start of the day.
         date.setHours(0, 0, 0, 0);
 
@@ -358,7 +361,7 @@
 
         var yearDay        = date.getDate()
           , weekDay        = date.getDay()
-          , dayInFirstWeek = 4 // January 4th
+          , dayInFirstWeek = firstWeekOfYearMinDays // January 4th
           , dayShift       = dayInFirstWeek - 1 // counting starts at 0
           , daysPerWeek    = 7
           , prevWeekDay    = function(day) { return (day + daysPerWeek - 1) % daysPerWeek; }
@@ -377,9 +380,9 @@
         return weekNum;
     },
 
-    renderWeek = function (d, m, y) {
+    renderWeek = function (d, m, y, firstWeekOfYearMinDays) {
         var date = new Date(y, m, d)
-          , week = hasMoment ? moment(date).isoWeek() : isoWeek(date)
+          , week = hasMoment ? moment(date).isoWeek() : isoWeek(date, firstWeekOfYearMinDays)
         ;
 
         return '<td class="pika-week">' + week + '</td>';
@@ -1213,7 +1216,7 @@
 
                 if (++r === 7) {
                     if (opts.showWeekNumber) {
-                        row.unshift(renderWeek(i - before, month, year));
+                        row.unshift(renderWeek(i - before, month, year, opts.firstWeekOfYearMinDays));
                     }
                     data.push(renderRow(row, opts.isRTL, opts.pickWholeWeek, isWeekSelected));
                     row = [];


### PR DESCRIPTION
Added new option **firstWeekOfYearMinDays** to support regional variations in week numbering rules. The new option makes it possible to support world-wide rule variations - when not using moment.

The change extends Pikaday's week number support which is currently limited to the ISO 8601 week numbering rule (week 1 = the first week with 4 days - considering Monday as the first day of the week).
https://en.wikipedia.org/wiki/ISO_week_date

The new added option is not mandatory and has a default value of 4, which means Pikadays current behavior is not altered when the option is not specified, it will default to the ISO 8601 rule.

_(In the project I am currently working on, I already have the firstWeekOfYearMinDays rule available since cldr-data is loaded for the current user's region/culture (https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/weekData.json).
The only small shortcoming I faced with respect to week numbers in Pikaday was to have the option that I implemented in this PR._