### PR TITLE
Center Pika-button Text Alignment

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -151,7 +151,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     color: #666;
     font-size: 12px;
     line-height: 15px;
-    text-align: right;
+    text-align: center;
     background: #f5f5f5;
 }
 


### PR DESCRIPTION
The current text-align: right on the pika-button class causes the calendar (and its contents) to appear unbalanced. Changing pika-button's text-align to center makes the calendar easier to read, and makes better use of horizontal spacing between dates.

![](https://user-images.githubusercontent.com/19237299/54159940-3a560600-441c-11e9-9442-c53941260273.png)
