### PR TITLE
fixed moment.js version as the older version is vulnerable

### DIFF
--- a/examples/moment.html
+++ b/examples/moment.html
@@ -28,7 +28,7 @@
     <p class="small">Copyright © 2014 <a href="https://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/rikkert">Ramiro Rikkert</a></p>
 
 
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.0/moment.min.js"></script>
     <script src="../pikaday.js"></script>
     <script>
 


### PR DESCRIPTION
In examples of moment.js , the sample html file included `2.5.0` version which is a vulnerable version as per the whitesource scanning. 

In my project, this is causing the security issue when pikaday in included as dependency in package.json

![image](https://user-images.githubusercontent.com/13137425/62830411-47299080-bc2c-11e9-8756-0ec1c89c7c28.png)
