### PR TITLE
Trigger_element-keypress-blur

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -548,8 +548,10 @@
                 switch(e.keyCode){
                     case 13:
                     case 27:
-                        if (opts.field) {
-                            opts.field.blur();
+                        if (opts.field && opts.trigger) {
+                          opts.field.focus();
+                        } else if(opts.field){
+                          opts.field.blur();
                         }
                         break;
                     case 37:


### PR DESCRIPTION
When there is a trigger element, enter and escape keypress does not blur the calender. One proposal is the focus goes back to field element, so user can see that change has been made. 