### PR TITLE
Prevent setting `position: static` inline when `container` option is passed

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -1252,9 +1252,12 @@
                 if (this._o.bound) {
                     removeEvent(document, 'click', this._onClick);
                 }
-                this.el.style.position = 'static'; // reset
-                this.el.style.left = 'auto';
-                this.el.style.top = 'auto';
+
+                if (!this._o.container) {
+                    this.el.style.position = 'static'; // reset
+                    this.el.style.left = 'auto';
+                    this.el.style.top = 'auto';
+                }
                 addClass(this.el, 'is-hidden');
                 this._v = false;
                 if (v !== undefined && typeof this._o.onClose === 'function') {


### PR DESCRIPTION
Fixes https://github.com/Pikaday/Pikaday/issues/840

When the `container` option is passed position is not set in the `adjustPosition` method but it is still set to `static` in the `hide` method. This makes it so you need to use `position: absolute !important` in your CSS to override the unnecessary inline styles. 

This PR adds the same check that is in `adjustPosition` to the `hide` method