### PR TITLE
docs: Fix simple typo, tekst -> text

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Pikaday has many useful options:
 * `field` bind the datepicker to a form field
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
-* `ariaLabel` data-attribute on the input field with an aria assistance tekst (only applied when `bound` is set)
+* `ariaLabel` data-attribute on the input field with an aria assistance text (only applied when `bound` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined)

--- a/pikaday.js
+++ b/pikaday.js
@@ -183,7 +183,7 @@
         // automatically show/hide the picker on `field` focus (default `true` if `field` is set)
         bound: undefined,
 
-        // data-attribute on the input field with an aria assistance tekst (only applied when `bound` is set)
+        // data-attribute on the input field with an aria assistance text (only applied when `bound` is set)
         ariaLabel: 'Use the arrow keys to pick a date',
 
         // position of the datepicker, relative to the field (default to bottom & left)


### PR DESCRIPTION
There is a small typo in README.md, pikaday.js.

Should read `text` rather than `tekst`.

