### PR TITLE
Remove showing on input change

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -594,9 +594,7 @@
             if (isDate(date)) {
               self.setDate(date);
             }
-            if (!self._v) {
-                self.show();
-            }
+            
         };
 
         self._onInputFocus = function()


### PR DESCRIPTION
When filling the field manually this line make the calendar flash open-close.
Worst, if I'm filling the form navigation with a keyboard, if I fill the date manually and tab to the next field it will open the calendar and it stays open ( even though I am not filling other fields)