### PR TITLE
fix(accessibility): screen reader being forced to read headings on day change

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -412,7 +412,7 @@
             opts = instance._o,
             isMinYear = year === opts.minYear,
             isMaxYear = year === opts.maxYear,
-            html = '<div id="' + randId + '" class="pika-title" role="heading" aria-live="assertive">',
+            html = '<div id="' + randId + '" class="pika-title" role="heading" aria-live="polite">',
             monthHtml,
             yearHtml,
             prev = true,


### PR DESCRIPTION
## Expected
Screen reader to properly read the selected date on keyboard navigation

## Issue
Screen reader is being forced to read content of `heading` element, because of `aria-live="assertive"` changing this to `polite` ensures the screen reader to read it after finishing the date change.


https://user-images.githubusercontent.com/6163988/134709516-12fa7c48-14e6-4009-bd50-52a9b418beed.mov


